### PR TITLE
fix: correct 'module' extension with .mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "password strength"
     ],
     "main": "dist/index.js",
-    "module": "dist/index.es.js",
+    "module": "dist/index.es.mjs",
     "browser": "dist/index.umd.js",
     "unpkg": "dist/index.umd.min.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
The esm build named with `index.es.mjs` but the package.json -> module was `index.es.js`, so it will broken in some esm env like vite.